### PR TITLE
480 version is not supported

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -38,6 +38,7 @@ import Data.List (intercalate, isPrefixOf)
 import Data.Maybe (fromMaybe)
 import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy as TL (unpack)
+import Data.Version (showVersion)
 import Data.Yaml (decodeFileThrow)
 import GHC.Generics (Generic)
 import Language.EO.Phi (Binding (..), Bytes (Bytes), Object (..), Program (Program), parseProgram, printTree)
@@ -59,6 +60,7 @@ import Language.EO.Phi.ToLaTeX
 import Main.Utf8
 import Options.Applicative hiding (metavar)
 import Options.Applicative qualified as Optparse (metavar)
+import Paths_eo_phi_normalizer (version)
 import PyF (fmt, fmtTrim)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath (takeDirectory)
@@ -375,10 +377,10 @@ cli =
         <> command commandNames.printRules commandParserInfo.printRules
     )
 
-cliOpts :: ParserInfo CLI
-cliOpts =
+cliOpts :: String -> ParserInfo CLI
+cliOpts version =
   info
-    (cli <**> helper)
+    (cli <**> helper <**> simpleVersioner version)
     (fullDesc <> progDesc "Work with PHI expressions.")
 
 data StructuredJSON = StructuredJSON
@@ -520,7 +522,7 @@ wrapRawBytesIn = \case
 
 main :: IO ()
 main = withUtf8 do
-  opts <- customExecParser pprefs cliOpts
+  opts <- customExecParser pprefs (cliOpts (showVersion version))
   let printAsProgramOrAsObject = \case
         Formation bindings' -> printTree $ Program bindings'
         x -> printTree x

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -378,9 +378,9 @@ cli =
     )
 
 cliOpts :: String -> ParserInfo CLI
-cliOpts version =
+cliOpts version' =
   info
-    (cli <**> helper <**> simpleVersioner version)
+    (cli <**> helper <**> simpleVersioner version')
     (fullDesc <> progDesc "Work with PHI expressions.")
 
 data StructuredJSON = StructuredJSON

--- a/site/docs/src/contributing.md
+++ b/site/docs/src/contributing.md
@@ -53,6 +53,7 @@ Usage: normalizer COMMAND
 
 Available options:
   -h,--help                Show this help text
+  --version                Show version information
 
 Available commands:
   transform                Transform a PHI program.
@@ -75,6 +76,7 @@ Usage: normalizer COMMAND
 
 Available options:
   -h,--help                Show this help text
+  --version                Show version information
 
 Available commands:
   transform                Transform a PHI program.

--- a/site/docs/src/normalizer.md
+++ b/site/docs/src/normalizer.md
@@ -13,6 +13,7 @@ Usage: normalizer COMMAND
 
 Available options:
   -h,--help                Show this help text
+  --version                Show version information
 
 Available commands:
   transform                Transform a PHI program.


### PR DESCRIPTION
- Closes #480

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces version information display in the command-line interface of the `eo-phi-normalizer` application and updates related documentation.

### Detailed summary
- Added `--version` option to `normalizer.md` and `contributing.md` documentation.
- Modified `cliOpts` function to accept a version string.
- Integrated `showVersion` from `Data.Version` to display the version in the CLI.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->