### PR TITLE
517 fix stream rules incorrectly modify the code produced by the opeo-maven-plugin

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/rules/streams.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/streams.yaml
@@ -5,16 +5,12 @@ rules:
       Replacing Java Stream's map with a for-each loop.
     context:
     forall:
-      - '!τ1'
       - '!b1'
       - '!b2'
+      - '!b3'
       - '!t1'
-      - '!B1'
     pattern: |
-       ⟦
-        !τ1 ↦ !b1.java_util_Stream$map(α0 ↦ !b2) * !t1,
-        !B1
-       ⟧
+       !b1.java_util_stream_Stream$map(α0 ↦ !b3, α1 ↦ !b2) * !t1
     result: |
       ⟦
         !τ2 ↦ !b1,
@@ -22,44 +18,43 @@ rules:
           α0 ↦ ξ.!τ2,
           α1 ↦ !b2
         ),
-        !τ1 ↦ ξ.!τ3 * !t1,
-        !B1
-      ⟧
+        φ ↦ ξ.!τ3 * !t1
+      ⟧.φ
     fresh:
       - name: '!τ2'
         prefix: 'foreach_body'
       - name: '!τ3'
-        prefix: 'java_util_Stream$map_result'
+        prefix: 'java_util_stream_Stream$map_result'
     when: []
     tests:
       - name: Simple map to for-each example works
         input: |
           ⟦
             list ↦ ∅,
-            result ↦ ξ.list.java_util_Stream$filter(
+            result ↦ ξ.list.java_util_stream_Stream$filter(
               α0 ↦ ⟦
                 el ↦ ∅,
                 φ ↦ ξ.el.equals(
                   α0 ↦ Φ.org.eolang.string(as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 00-))
                 ).not
               ⟧
-            ).java_util_Stream$map(
+            ).java_util_stream_Stream$map(
               α0 ↦ ⟦
                 el ↦ ∅,
                 φ ↦ Φ.java_util_Integer.parseInt(
                   α0 ↦ ξ.el
                 )
               ⟧
-            ).java_util_Stream$toList
+            ).java_util_stream_Stream$toList
           ⟧
         output:
           - |
             ⟦
-              foreach_body$1 ↦ ξ.list.java_util_Stream$filter (α0 ↦ ⟦
+              foreach_body$1 ↦ ξ.list.java_util_stream_Stream$filter (α0 ↦ ⟦
                 el ↦ ∅, φ ↦ ξ.el.equals (α0 ↦ Φ.org.eolang.string (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 00-))).not
               ⟧),
-              java_util_Stream$map_result$1 ↦ Φ.opeo.map-for-each (α0 ↦ ξ.foreach_body$1, α1 ↦ ⟦
+              java_util_stream_Stream$map_result$1 ↦ Φ.opeo.map-for-each (α0 ↦ ξ.foreach_body$1, α1 ↦ ⟦
                 el ↦ ∅, φ ↦ Φ.java_util_Integer.parseInt (α0 ↦ ξ.el)
               ⟧),
-              result ↦ ξ.java_util_Stream$map_result$1.java_util_Stream$toList, list ↦ ∅
+              result ↦ ξ.java_util_stream_Stream$map_result$1.java_util_stream_Stream$toList, list ↦ ∅
             ⟧


### PR DESCRIPTION
- Closes #517

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the naming conventions in the `streams.yaml` file to use the correct package names for Java streams, changing `java_util_Stream` to `java_util_stream_Stream` throughout the file.

### Detailed summary
- Updated `forall` section, replacing `!b2` with `!b3`.
- Changed pattern from `!b1.java_util_Stream$map` to `!b1.java_util_stream_Stream$map`.
- Updated `fresh` prefix from `java_util_Stream$map_result` to `java_util_stream_Stream$map_result`.
- Modified test cases to reflect the new package names, including `java_util_Stream$filter` and `java_util_Stream$toList`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->