### PR TITLE
538 update macos runner in ci

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     steps:
       - name: 📥 Checkout repository
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     permissions:
       contents: write


### PR DESCRIPTION
- Closes #538

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the operating system configurations in the GitHub Actions workflow file `.github/workflows/ghc.yml` to use `macos-latest` instead of a specific version.

### Detailed summary
- Changed the `os` matrix from `macos-12` to `macos-latest` in the GitHub Actions workflow.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->