### PR TITLE
580 lets add oneline option to the rewrite command

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -98,6 +98,7 @@ data CLI'RewritePhi = CLI'RewritePhi
   , rulesPath :: Maybe String
   , outputFile :: Maybe String
   , single :: Bool
+  , singleLine :: Bool
   , json :: Bool
   , latex :: Bool
   , inputFile :: Maybe FilePath
@@ -292,7 +293,10 @@ commandParser =
     json <- jsonSwitch
     latex <- latexSwitch
     outputFile <- outputFileOption
-    single <- switch (long "single" <> short 's' <> help "Output a single expression.")
+    let singleFlag :: String
+        singleFlag = "single"
+    single <- switch (long singleFlag <> short 's' <> help "Output a single expression.")
+    singleLine <- switch (long "single-line" <> short 'l' <> help [fmt|Output a single expression on a single line. Has effect only if the --{singleFlag} is enabled.|])
     maxDepth <-
       let maxValue = 10
        in option auto (long "max-depth" <> metavar.int <> value maxValue <> help [fmt|Maximum depth of rules application. Defaults to {maxValue}.|])
@@ -614,8 +618,10 @@ main = withUtf8 do
               . encodeToJSONString
               . printAsProgramOrAsObject
               $ logEntryLog (head (head uniqueResults))
-        | single ->
+        | single -> do
+            let removeExtraSpaces = unwords . words
             logStrLn
+              . (if singleLine then removeExtraSpaces else id)
               . printAsProgramOrAsObject
               $ logEntryLog (head (head uniqueResults))
         | json ->

--- a/site/docs/src/eo-phi-normalizer/rewrite.md
+++ b/site/docs/src/eo-phi-normalizer/rewrite.md
@@ -212,6 +212,16 @@ eo-phi-normalizer rewrite --single --rules ./eo-phi-normalizer/test/eo/phi/rules
 }
 ```
 
+### `--single --single-line`
+
+```$ as console
+eo-phi-normalizer rewrite --single --single-line --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml celsius.phi
+```
+
+```console
+{ ⟦ c ↦ Φ.org.eolang.float ( as-bytes ↦ Φ.org.eolang.bytes ( Δ ⤍ 40-39-00-00-00-00-00-00 ) ), result ↦ ξ.c.times ( x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧ ) .plus ( x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧ ), λ ⤍ Package ⟧ }
+```
+
 ### `--single` `--json`
 
 ```$ as console

--- a/site/docs/src/eo-phi-normalizer/rewrite.md
+++ b/site/docs/src/eo-phi-normalizer/rewrite.md
@@ -23,8 +23,9 @@ eo-phi-normalizer rewrite --help
 ```console
 Usage: eo-phi-normalizer rewrite [-r|--rules FILE] [-c|--chain] [-j|--json]
                                  [--tex] [-o|--output-file FILE] [-s|--single]
-                                 [--max-depth INT] [--max-growth-factor INT]
-                                 [FILE] [-d|--dependency-file FILE]
+                                 [-l|--single-line] [--max-depth INT]
+                                 [--max-growth-factor INT] [FILE]
+                                 [-d|--dependency-file FILE]
 
   Rewrite a PHI program.
 
@@ -37,6 +38,8 @@ Available options:
   -o,--output-file FILE    Output to FILE. When this option is not specified,
                            output to stdout.
   -s,--single              Output a single expression.
+  -l,--single-line         Output a single expression on a single line. Has
+                           effect only if the --single is enabled.
   --max-depth INT          Maximum depth of rules application. Defaults to 10.
   --max-growth-factor INT  The factor by which to allow the input term to grow
                            before stopping. Defaults to 10.


### PR DESCRIPTION
- Related to #580

I've implemented the `single-line` option that prints a single expression on a single line. This option relies on the `single` option. Hence, the name is `single-line`, and not `one-line` as suggested originally.

Another reason is that ChatGPT thinks "single line" is used more commonly:

> The correct expression is "on a single line."
> 
> When referring to text or code being written or displayed in one continuous row without line breaks, the phrase "on a single line" is the most common and accurate usage. For example, you would say, "Please print the output on a single line."
> 
> "In one line" is less commonly used, but it could still be understood in certain contexts. However, "on a single line" is the more conventional choice.
> 
