### PR TITLE
Fix issues related to LaTeX

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -63,7 +63,7 @@ import Data.List (intercalate, isPrefixOf)
 import Data.Maybe (fromMaybe)
 import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy as TL (unpack)
-import Data.Text.Lazy.Manipulate
+import Data.Text.Lazy.Manipulate (toOrdinal)
 import Data.Version (showVersion)
 import Data.Yaml (decodeFileThrow, decodeThrow)
 import GHC.Generics (Generic)

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -663,8 +663,8 @@ main = withUtf8 do
                         latexLines
                         transitions
               unless (length uniqueResults == 1) $
-                logStrLn $
-                  "\nThis is the " <> unpack (toOrdinal index) <> " possible chain of normalizing rewritings:\n"
+                logStrLn
+                  [fmt|\nThis is the {unpack (toOrdinal index)} possible chain of normalizing rewritings:\n|]
               inPhiEquation linesCombined
         | latex ->
             inLatexDocument $

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -597,7 +597,7 @@ main = withUtf8 do
           Nothing -> do
             ruleSet :: RuleSet <- decodeThrow $(embedFileRelative "test/eo/phi/rules/new.yaml")
             return (False, ruleSet.title, convertRuleNamed <$> ruleSet.rules)
-      unless (single || json || (chain && latex)) $ logStrLn ruleSetTitle
+      unless (single || json || latex) $ logStrLn ruleSetTitle
       bindingsWithDeps <- case deepMergePrograms (program' : deps) of
         Left err -> throw (CouldNotMergeDependencies err)
         Right (Program bindingsWithDeps) -> return bindingsWithDeps
@@ -647,8 +647,19 @@ main = withUtf8 do
               logStrLn [fmtTrim|{linesCombined}|]
               logStrLn "\\end{phiquation*}"
             logStrLn "\n\\end{document}"
-        | latex ->
+        | latex -> do
+            logStrLn
+              [fmtTrim|
+                % {ruleSetTitle}
+
+                \\documentclass{{article}}
+                \\usepackage{{eolang}}
+                \\begin{{document}}
+              |]
+            logStrLn "\\begin{phiquation*}"
             logStrLn . toLatexString $ logEntryLog (head (head uniqueResults))
+            logStrLn "\\end{phiquation*}"
+            logStrLn "\n\\end{document}"
         | otherwise -> do
             logStrLn "Input:"
             logStrLn (printTree program')

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -269,6 +269,7 @@ library
     , scientific
     , template-haskell
     , text
+    , text-manipulate
     , unordered-containers
     , yaml
   default-language: Haskell2010
@@ -313,6 +314,7 @@ executable eo-phi-normalizer
     , scientific
     , template-haskell
     , text
+    , text-manipulate
     , unordered-containers
     , with-utf8
     , yaml
@@ -387,6 +389,7 @@ test-suite doctests
     , scientific
     , template-haskell
     , text
+    , text-manipulate
     , unordered-containers
     , yaml
   default-language: Haskell2010
@@ -439,6 +442,7 @@ test-suite spec
     , scientific
     , template-haskell
     , text
+    , text-manipulate
     , unordered-containers
     , with-utf8
     , yaml

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -76,6 +76,7 @@ dependencies:
   - hspec-core
   - text
   - template-haskell
+  - text-manipulate
   - blaze-html
   - blaze-markup
   - scientific


### PR DESCRIPTION
Addresses #595, #596, #599

- Make LaTeX output parseable when `--chain` is not used
- When there are several chains, print messages that enumerate them
- Add trailing `\trans` in chains
