### PR TITLE
610 fix command output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,18 @@ Check open issues ([link](https://github.com/objectionary/eo-phi-normalizer/issu
 
 ## Enter the repository
 
+<!-- `> cat site/docs/src/common/enter-repository.md` -->
+
+<!-- BEGIN mdsh -->
+
 Clone and enter the project repository.
 
 ```sh
 git clone https://github.com/objectionary/eo-phi-normalizer --recurse-submodules
 cd eo-phi-normalizer
 ```
+
+<!-- END mdsh -->
 
 ## Install stack
 

--- a/eo-phi-normalizer/src/Language/EO/Locale.hs
+++ b/eo-phi-normalizer/src/Language/EO/Locale.hs
@@ -26,7 +26,7 @@
 
 module Language.EO.Locale where
 
-import Control.Exception (Exception (..), SomeException, catch)
+import Control.Exception (Exception (..), Handler (..), SomeException, catches)
 import Main.Utf8 (withUtf8)
 import System.Exit (ExitCode (..), exitWith)
 import System.IO.CodePage (withCP65001)
@@ -35,8 +35,9 @@ withCorrectLocale :: IO a -> IO a
 withCorrectLocale act = do
   let withCorrectLocale' = withCP65001 . withUtf8
   withCorrectLocale' act
-    `catch` ( \(x :: SomeException) ->
-                withCorrectLocale' do
-                  putStrLn (displayException x)
-                  exitWith (ExitFailure 1)
-            )
+    `catches` [ Handler $ \(x :: ExitCode) -> exitWith x
+              , Handler $ \(x :: SomeException) ->
+                  withCorrectLocale' do
+                    putStrLn (displayException x)
+                    exitWith (ExitFailure 1)
+              ]

--- a/flake.nix
+++ b/flake.nix
@@ -215,7 +215,7 @@
                       "contributing.md"
                     ]}
 
-                    cp site/docs/docs/markdown/contributing.md CONTRIBUTING.md
+                    cp site/docs/src/contributing.md CONTRIBUTING.md
 
                     rm celsius.phi
 

--- a/flake.nix
+++ b/flake.nix
@@ -199,7 +199,7 @@
                 let
                   name = "update-markdown";
                   text = ''
-                    mdsh
+                    set -ex
 
                     ${lib.concatMapStringsSep "\n" (x: "mdsh -i site/docs/src/${x} --work_dir .") [
                       "common/celsius.md"

--- a/scripts/update-markdown.sh
+++ b/scripts/update-markdown.sh
@@ -25,7 +25,7 @@
 
 # This file was generated automatically.
 # You can edit the script in 'flake.nix'
-mdsh
+set -ex
 
 mdsh -i site/docs/src/common/celsius.md --work_dir .
 mdsh -i site/docs/src/eo-phi-normalizer.md --work_dir .

--- a/scripts/update-markdown.sh
+++ b/scripts/update-markdown.sh
@@ -39,7 +39,7 @@ mdsh -i site/docs/src/eo-phi-normalizer/print-rules.md --work_dir .
 mdsh -i site/docs/src/eo-phi-normalizer/test.md --work_dir .
 mdsh -i site/docs/src/contributing.md --work_dir .
 
-cp site/docs/docs/markdown/contributing.md CONTRIBUTING.md
+cp site/docs/src/contributing.md CONTRIBUTING.md
 
 rm celsius.phi
 

--- a/site/docs/src/eo-phi-normalizer/metrics.md
+++ b/site/docs/src/eo-phi-normalizer/metrics.md
@@ -18,7 +18,7 @@ eo-phi-normalizer metrics --help
 
 ```console
 Usage: eo-phi-normalizer metrics [FILE] [-o|--output-file FILE]
-                          [-b|--bindings-path PATH]
+                                 [-b|--bindings-path PATH]
 
   Collect metrics for a PHI program.
 
@@ -44,10 +44,10 @@ eo-phi-normalizer metrics celsius.phi
 {
   "bindings-by-path-metrics": null,
   "program-metrics": {
-    "applications": 3,
-    "dataless": 6,
-    "dispatches": 6,
-    "formations": 8
+    "applications": 4,
+    "dataless": 1,
+    "dispatches": 9,
+    "formations": 3
   }
 }
 ```
@@ -62,10 +62,10 @@ cat celsius.phi | eo-phi-normalizer metrics
 {
   "bindings-by-path-metrics": null,
   "program-metrics": {
-    "applications": 3,
-    "dataless": 6,
-    "dispatches": 6,
-    "formations": 8
+    "applications": 4,
+    "dataless": 1,
+    "dispatches": 9,
+    "formations": 3
   }
 }
 ```
@@ -82,21 +82,30 @@ eo-phi-normalizer metrics --bindings-path '' celsius.phi
     "bindings-metrics": [
       {
         "metrics": {
-          "applications": 0,
-          "dataless": 3,
-          "dispatches": 0,
-          "formations": 3
+          "applications": 2,
+          "dataless": 0,
+          "dispatches": 6,
+          "formations": 0
         },
-        "name": "float"
+        "name": "c"
+      },
+      {
+        "metrics": {
+          "applications": 2,
+          "dataless": 0,
+          "dispatches": 3,
+          "formations": 2
+        },
+        "name": "result"
       }
     ],
-    "path": "org.eolang"
+    "path": ""
   },
   "program-metrics": {
-    "applications": 3,
-    "dataless": 6,
-    "dispatches": 6,
-    "formations": 8
+    "applications": 4,
+    "dataless": 1,
+    "dispatches": 9,
+    "formations": 3
   }
 }
 ```

--- a/site/docs/src/eo-phi-normalizer/metrics.md
+++ b/site/docs/src/eo-phi-normalizer/metrics.md
@@ -73,7 +73,7 @@ cat celsius.phi | eo-phi-normalizer metrics
 ### `--bindings-path`
 
 ```$ as console
-eo-phi-normalizer metrics --bindings-path org.eolang celsius.phi
+eo-phi-normalizer metrics --bindings-path '' celsius.phi
 ```
 
 ```console


### PR DESCRIPTION
- Closes #610

Changes:
- Applied a temporary fix to a failing command in the documentation
- Implemented correct handling of ExitSuccess
- Removed the dependency of `contributing.md` on mdBook features (actually, there was only one - #include).