### PR TITLE
Sort options in command help messages

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -283,47 +283,47 @@ commandParser =
   CommandParser{..}
  where
   metrics = do
-    inputFile <- inputFileArg
-    outputFile <- outputFileOption
     bindingsPath <- bindingsPathOption
+    outputFile <- outputFileOption
+    inputFile <- inputFileArg
     pure CLI'MetricsPhi{..}
   printRules = do
+    compact <- compactSwitch
     rulesPath <- optional $ strOption (long "rules" <> short 'r' <> metavar.file <> help [fmt|{metavarName.file} with user-defined rules. If unspecified, {rulesFile} is rendered.|])
     latex <- latexSwitch
-    compact <- compactSwitch
     pure CLI'PrintRules{..}
   rewrite = do
-    rulesPath <- optional $ strOption (long "rules" <> short 'r' <> metavar.file <> help [fmt|{metavarName.file} with user-defined rules. If unspecified, builtin set of rules is used.|])
     chain <- switch (long "chain" <> short 'c' <> help "Output rewriting steps.")
+    dependencies <- dependenciesArg
     json <- jsonSwitch
-    latex <- latexSwitch
-    outputFile <- outputFileOption
-    let singleFlag :: String
-        singleFlag = "single"
-    single <- switch (long singleFlag <> short 's' <> help "Output a single expression.")
-    singleLine <- switch (long "single-line" <> short 'l' <> help [fmt|Output a single expression on a single line. Has effect only if the --{singleFlag} is enabled.|])
     maxDepth <-
       let maxValue = 10
        in option auto (long "max-depth" <> metavar.int <> value maxValue <> help [fmt|Maximum depth of rules application. Defaults to {maxValue}.|])
     maxGrowthFactor <-
       let maxValue = 10
        in option auto (long "max-growth-factor" <> metavar.int <> value maxValue <> help [fmt|The factor by which to allow the input term to grow before stopping. Defaults to {maxValue}.|])
+    outputFile <- outputFileOption
+    rulesPath <- optional $ strOption (long "rules" <> short 'r' <> metavar.file <> help [fmt|{metavarName.file} with user-defined rules. If unspecified, builtin set of rules is used.|])
+    let singleFlag :: String
+        singleFlag = "single"
+    single <- switch (long singleFlag <> short 's' <> help "Output a single expression.")
+    singleLine <- switch (long "single-line" <> short 'l' <> help [fmt|Output a single expression on a single line. Has effect only if the --{singleFlag} is enabled.|])
+    latex <- latexSwitch
     inputFile <- inputFileArg
-    dependencies <- dependenciesArg
     pure CLI'RewritePhi{..}
   dataize = do
-    rulesPath <- optional $ strOption (long "rules" <> short 'r' <> metavar.file <> help [fmt|{metavarName.file} with user-defined rules. If unspecified, builtin set of rules is used.|])
-    inputFile <- inputFileArg
-    dependencies <- dependenciesArg
-    outputFile <- outputFileOption
-    recursive <- switch (long "recursive" <> help "Apply dataization + normalization recursively.")
-    chain <- switch (long "chain" <> help "Display all the intermediate steps.")
-    wrapRawBytes <- switch (long "wrap-raw-bytes" <> help "Wrap raw bytes ⟦ Δ ⤍ 01- ⟧ as Φ.org.eolang.bytes(Δ ⤍ 01-) in the final output.")
-    latex <- latexSwitch
     asPackage <- asPackageSwitch
-    minimizeStuckTerms <- minimizeStuckTermsSwitch
+    chain <- switch (long "chain" <> help "Display all the intermediate steps.")
+    dependencies <- dependenciesArg
     disabledAtomNames <- many $ strOption (long "disable-atom" <> metavar.atomName <> help "Name of an atom to disable.")
     enabledAtomNames <- many $ strOption (long "enable-atom" <> metavar.atomName <> help "Name of an atom to enable.")
+    minimizeStuckTerms <- minimizeStuckTermsSwitch
+    outputFile <- outputFileOption
+    recursive <- switch (long "recursive" <> help "Apply dataization + normalization recursively.")
+    rulesPath <- optional $ strOption (long "rules" <> short 'r' <> metavar.file <> help [fmt|{metavarName.file} with user-defined rules. If unspecified, builtin set of rules is used.|])
+    latex <- latexSwitch
+    wrapRawBytes <- switch (long "wrap-raw-bytes" <> help "Wrap raw bytes ⟦ Δ ⤍ 01- ⟧ as Φ.org.eolang.bytes(Δ ⤍ 01-) in the final output.")
+    inputFile <- inputFileArg
     pure CLI'DataizePhi{..}
   pipeline' =
     CommandParser'Pipeline
@@ -335,8 +335,8 @@ commandParser =
           pure CLI'Pipeline'PrepareTests{..}
       , printDataizeConfigs = do
           configFile <- strOption (long "config" <> short 'c' <> metavar.file <> help [fmt|A pipeline tests configuration {metavarName.file}.|])
-          phiPrefixesToStrip <- many $ strOption (long "strip-phi-prefix" <> short 'p' <> metavar.path <> help [fmt|{metavarName.path} prefix to remove in PHI file paths.|])
           singleLine <- switch (long "single-line" <> short 'l' <> help [fmt|Output configs on an single line.|])
+          phiPrefixesToStrip <- many $ strOption (long "strip-phi-prefix" <> short 'p' <> metavar.path <> help [fmt|{metavarName.path} prefix to remove in PHI file paths.|])
           pure CLI'Pipeline'PrintDataizeConfigs{..}
       }
   pipeline =

--- a/site/docs/src/eo-phi-normalizer/dataize.md
+++ b/site/docs/src/eo-phi-normalizer/dataize.md
@@ -13,38 +13,39 @@ eo-phi-normalizer dataize --help
 ```
 
 ```console
-Usage: eo-phi-normalizer dataize [-r|--rules FILE] [FILE]
+Usage: eo-phi-normalizer dataize [--as-package] [--chain]
                                  [-d|--dependency-file FILE]
-                                 [-o|--output-file FILE] [--recursive] [--chain]
-                                 [--wrap-raw-bytes] [--tex] [--as-package]
-                                 [--minimize-stuck-terms]
                                  [--disable-atom ATOM_NAME]
                                  [--enable-atom ATOM_NAME]
+                                 [--minimize-stuck-terms]
+                                 [-o|--output-file FILE] [--recursive]
+                                 [-r|--rules FILE] [--tex] [--wrap-raw-bytes]
+                                 [FILE]
 
   Dataize a PHI program.
 
 Available options:
-  -r,--rules FILE          FILE with user-defined rules. If unspecified, builtin
-                           set of rules is used.
-  FILE                     FILE to read input from. When no FILE is specified,
-                           read from stdin.
+  --as-package             Automatically inject (λ → Package) in the program if
+                           necessary, to dataize all fields.
+  --chain                  Display all the intermediate steps.
   -d,--dependency-file FILE
                            FILE to read dependencies from (zero or more
                            dependency files allowed).
-  -o,--output-file FILE    Output to FILE. When this option is not specified,
-                           output to stdout.
-  --recursive              Apply dataization + normalization recursively.
-  --chain                  Display all the intermediate steps.
-  --wrap-raw-bytes         Wrap raw bytes ⟦ Δ ⤍ 01- ⟧ as Φ.org.eolang.bytes(Δ ⤍
-                           01-) in the final output.
-  --tex                    Output LaTeX.
-  --as-package             Automatically inject (λ → Package) in the program if
-                           necessary, to dataize all fields.
+  --disable-atom ATOM_NAME Name of an atom to disable.
+  --enable-atom ATOM_NAME  Name of an atom to enable.
   --minimize-stuck-terms   If a dataized (sub)term is stuck (cannot be fully
                            dataized), use the minimal (by size) intermediate
                            result.
-  --disable-atom ATOM_NAME Name of an atom to disable.
-  --enable-atom ATOM_NAME  Name of an atom to enable.
+  -o,--output-file FILE    Output to FILE. When this option is not specified,
+                           output to stdout.
+  --recursive              Apply dataization + normalization recursively.
+  -r,--rules FILE          FILE with user-defined rules. If unspecified, builtin
+                           set of rules is used.
+  --tex                    Output LaTeX.
+  --wrap-raw-bytes         Wrap raw bytes ⟦ Δ ⤍ 01- ⟧ as Φ.org.eolang.bytes(Δ ⤍
+                           01-) in the final output.
+  FILE                     FILE to read input from. When no FILE is specified,
+                           read from stdin.
   -h,--help                Show this help text
 ```
 

--- a/site/docs/src/eo-phi-normalizer/metrics.md
+++ b/site/docs/src/eo-phi-normalizer/metrics.md
@@ -17,20 +17,20 @@ eo-phi-normalizer metrics --help
 ```
 
 ```console
-Usage: eo-phi-normalizer metrics [FILE] [-o|--output-file FILE]
-                                 [-b|--bindings-path PATH]
+Usage: eo-phi-normalizer metrics [-b|--bindings-path PATH]
+                                 [-o|--output-file FILE] [FILE]
 
   Collect metrics for a PHI program.
 
 Available options:
-  FILE                     FILE to read input from. When no FILE is specified,
-                           read from stdin.
-  -o,--output-file FILE    Output to FILE. When this option is not specified,
-                           output to stdout.
   -b,--bindings-path PATH  Report metrics for bindings of a formation accessible
                            in a program by the PATH. When this option is not
                            specified, metrics for bindings are not reported.
                            Example of a PATH: 'org.eolang'.
+  -o,--output-file FILE    Output to FILE. When this option is not specified,
+                           output to stdout.
+  FILE                     FILE to read input from. When no FILE is specified,
+                           read from stdin.
   -h,--help                Show this help text
 ```
 

--- a/site/docs/src/eo-phi-normalizer/print-rules.md
+++ b/site/docs/src/eo-phi-normalizer/print-rules.md
@@ -9,15 +9,15 @@ eo-phi-normalizer print-rules --help
 ```
 
 ```console
-Usage: eo-phi-normalizer print-rules [-r|--rules FILE] [--tex] [-c|--compact]
+Usage: eo-phi-normalizer print-rules [-c|--compact] [-r|--rules FILE] [--tex]
 
   Print rules in LaTeX format.
 
 Available options:
+  -c,--compact             Print rules, each on a single line.
   -r,--rules FILE          FILE with user-defined rules. If unspecified,
                            yegor.yaml is rendered.
   --tex                    Output LaTeX.
-  -c,--compact             Print rules, each on a single line.
   -h,--help                Show this help text
 ```
 

--- a/site/docs/src/eo-phi-normalizer/rewrite.md
+++ b/site/docs/src/eo-phi-normalizer/rewrite.md
@@ -21,33 +21,33 @@ eo-phi-normalizer rewrite --help
 ```
 
 ```console
-Usage: eo-phi-normalizer rewrite [-r|--rules FILE] [-c|--chain] [-j|--json]
-                                 [--tex] [-o|--output-file FILE] [-s|--single]
-                                 [-l|--single-line] [--max-depth INT]
-                                 [--max-growth-factor INT] [FILE]
-                                 [-d|--dependency-file FILE]
+Usage: eo-phi-normalizer rewrite [-c|--chain] [-d|--dependency-file FILE]
+                                 [-j|--json] [--max-depth INT]
+                                 [--max-growth-factor INT]
+                                 [-o|--output-file FILE] [-r|--rules FILE]
+                                 [-s|--single] [-l|--single-line] [--tex] [FILE]
 
   Rewrite a PHI program.
 
 Available options:
-  -r,--rules FILE          FILE with user-defined rules. If unspecified, builtin
-                           set of rules is used.
   -c,--chain               Output rewriting steps.
-  -j,--json                Output JSON.
-  --tex                    Output LaTeX.
-  -o,--output-file FILE    Output to FILE. When this option is not specified,
-                           output to stdout.
-  -s,--single              Output a single expression.
-  -l,--single-line         Output a single expression on a single line. Has
-                           effect only if the --single is enabled.
-  --max-depth INT          Maximum depth of rules application. Defaults to 10.
-  --max-growth-factor INT  The factor by which to allow the input term to grow
-                           before stopping. Defaults to 10.
-  FILE                     FILE to read input from. When no FILE is specified,
-                           read from stdin.
   -d,--dependency-file FILE
                            FILE to read dependencies from (zero or more
                            dependency files allowed).
+  -j,--json                Output JSON.
+  --max-depth INT          Maximum depth of rules application. Defaults to 10.
+  --max-growth-factor INT  The factor by which to allow the input term to grow
+                           before stopping. Defaults to 10.
+  -o,--output-file FILE    Output to FILE. When this option is not specified,
+                           output to stdout.
+  -r,--rules FILE          FILE with user-defined rules. If unspecified, builtin
+                           set of rules is used.
+  -s,--single              Output a single expression.
+  -l,--single-line         Output a single expression on a single line. Has
+                           effect only if the --single is enabled.
+  --tex                    Output LaTeX.
+  FILE                     FILE to read input from. When no FILE is specified,
+                           read from stdin.
   -h,--help                Show this help text
 ```
 


### PR DESCRIPTION
- Addresses #633

Changes:
- Sorted options by the long option name.
- Left the `--help` option as is because changing its position in the full option list seems to be non-trivial.
